### PR TITLE
Change xxx.xxx to example.com in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,5 @@ STRIPE_SECRET_KEY: xxx
 
 PAYEE_NAME: xxx
 PAYEE_TWITTER: xxx
-PAYEE_SITE: xxx.xxx
-PAYEE_SITE_URL: http://xxx.xxx
+PAYEE_SITE: example.com
+PAYEE_SITE_URL: http://example.com


### PR DESCRIPTION
xxx.xxx is a valid domain name and resolves to a porn directory. While this probably isn't an Apple sized problem ( http://goo.gl/aQaq4 ), it's probably better to use an actual example domain anyways.
